### PR TITLE
Update Makefile to Include dlr.proto in Proto-Generate Command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ proto-generate: ## Protobuf Generate
 		pkg/proto/model/authentication.proto \
 		pkg/proto/model/authorization.proto \
 		pkg/proto/model/user.proto \
+		pkg/proto/model/dlr.proto \
 		--experimental_allow_proto3_optional
 
 ## Help:


### PR DESCRIPTION
Closes #14 

This pull request updates the proto-generate command in the Makefile to include pkg/proto/model/dlr.proto. This change ensures that dlr.proto is included in the protobuf code generation process, addressing the previously missing protobuf file necessary for generating the Go code.

By incorporating this update, we can ensure that all required protobuf files are correctly processed during the build, maintaining consistency and completeness in our generated code.
